### PR TITLE
Added ItemStack reference to IBauble methods.

### DIFF
--- a/src/main/java/com/lazy/baubles/api/IBauble.java
+++ b/src/main/java/com/lazy/baubles/api/IBauble.java
@@ -20,19 +20,19 @@ public interface IBauble {
     /**
      * This method is called once per tick if the bauble is being worn by a player
      */
-    default void onWornTick(LivingEntity player) {
+    default void onWornTick(LivingEntity player, net.minecraft.item.ItemStack stackIn) {/* Changed: Added argument ItemStack stackIn. */
     }
 
     /**
      * This method is called when the bauble is equipped by a player
      */
-    default void onEquipped(LivingEntity player) {
+    default void onEquipped(LivingEntity player, net.minecraft.item.ItemStack stackIn) {/* Changed: Added argument ItemStack stackIn. */
     }
 
     /**
      * This method is called when the bauble is unequipped by a player
      */
-    default void onUnequipped(LivingEntity player) {
+    default void onUnequipped(LivingEntity player, net.minecraft.item.ItemStack stackIn) {/* Changed: Added argument ItemStack stackIn. */
     }
 
     /**

--- a/src/main/java/com/lazy/baubles/api/cap/BaublesContainer.java
+++ b/src/main/java/com/lazy/baubles/api/cap/BaublesContainer.java
@@ -79,7 +79,7 @@ public class BaublesContainer extends ItemStackHandler implements IBaublesItemHa
         for (int i = 0; i < getSlots(); i++) {
             ItemStack stack = getStackInSlot(i);
             stack.getCapability(BaublesCapabilities.ITEM_BAUBLE)
-                    .ifPresent(b -> b.onWornTick(holder));
+                    .ifPresent(b -> b.onWornTick(holder, stack));/* Changed: updated input argument stack. */
         }
         sync();
     }

--- a/src/main/java/com/lazy/baubles/container/PlayerExpandedContainer.java
+++ b/src/main/java/com/lazy/baubles/container/PlayerExpandedContainer.java
@@ -187,7 +187,7 @@ public class PlayerExpandedContainer extends Container {
 
             if (itemstack1.isEmpty() && !baubles.isEventBlocked() && slot instanceof SlotBauble && itemstack.getCapability(BaublesCapabilities.ITEM_BAUBLE, null).isPresent()) {
                 ItemStack finalItemstack = itemstack;
-                itemstack.getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble -> iBauble.onEquipped(playerIn)));
+                itemstack.getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble -> iBauble.onEquipped(playerIn, finalItemstack)));/* Changed: updated input argument stack. */
             }
 
             ItemStack itemstack2 = slot.onTake(playerIn, itemstack1);

--- a/src/main/java/com/lazy/baubles/container/slots/SlotBauble.java
+++ b/src/main/java/com/lazy/baubles/container/slots/SlotBauble.java
@@ -38,7 +38,7 @@ public class SlotBauble extends SlotItemHandler {
     @Override
     public ItemStack onTake(PlayerEntity playerIn, ItemStack stack) {
         if (!getHasStack() && !((IBaublesItemHandler) getItemHandler()).isEventBlocked() && stack.getCapability(BaublesCapabilities.ITEM_BAUBLE).isPresent()) {
-            stack.getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble)->iBauble.onUnequipped(playerIn));
+            stack.getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble)->iBauble.onUnequipped(playerIn, stack));/* Changed: updated input argument stack. */
         }
         super.onTake(playerIn, stack);
         return stack;
@@ -47,14 +47,14 @@ public class SlotBauble extends SlotItemHandler {
     @Override
     public void putStack(ItemStack stack) {
         if (getHasStack() && !ItemStack.areItemStacksEqual(stack, getStack()) && !((IBaublesItemHandler) getItemHandler()).isEventBlocked() && getStack().getCapability(BaublesCapabilities.ITEM_BAUBLE, null).isPresent()) {
-            getStack().getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble)->iBauble.onUnequipped(player));
+            getStack().getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble)->iBauble.onUnequipped(player, stack));/* Changed: updated input argument stack. */
         }
 
         ItemStack oldstack = getStack().copy();
         super.putStack(stack);
 
         if (getHasStack() && !ItemStack.areItemStacksEqual(oldstack, getStack()) && !((IBaublesItemHandler) getItemHandler()).isEventBlocked() && getStack().getCapability(BaublesCapabilities.ITEM_BAUBLE, null).isPresent()) {
-            getStack().getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble)->iBauble.onEquipped(player));
+            getStack().getCapability(BaublesCapabilities.ITEM_BAUBLE, null).ifPresent((iBauble)->iBauble.onEquipped(player, stack));
         }
     }
 

--- a/src/main/java/com/lazy/baubles/event/EventHandlerEntity.java
+++ b/src/main/java/com/lazy/baubles/event/EventHandlerEntity.java
@@ -7,7 +7,7 @@ import com.lazy.baubles.api.cap.BaublesContainerProvider;
 import com.lazy.baubles.api.cap.IBaublesItemHandler;
 import com.lazy.baubles.network.PacketHandler;
 import com.lazy.baubles.network.SyncPacket;
-import com.sun.javafx.geom.Vec3f;
+//import com.sun.javafx.geom.Vec3f; Unused
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;


### PR DESCRIPTION
+Added an ItemStack argument to com.lazy.baubles.api.IBauble#onWornTick, IBauble#onEquipped and IBauble#onUnequipped.

*Was 'onWornTick(LivingEntity player)', is now 'onWornTick(LivingEntity player, ItemStack stackIn)'.

*Was 'onEquipped(LivingEntity player)', is now 'onEquipped(LivingEntity player, ItemStack stackIn)'.

*Was 'onUnequipped(LivingEntity player)', is now 'onUnequipped(LivingEntity player, ItemStack stackIn)'.

+Updated relevant references for these methods.

This is to match the previous versions of Azanor's Baubles, which had a reference to the relevant ItemStack in the functional methods. Hoping for this change to be implemented and an updated version (API included) to be released; I suggest 1.7.2.