### PR TITLE
[1.18.1] Fix unobfuscated method name in findMethod call

### DIFF
--- a/src/main/java/lazy/baubles/container/PlayerExpandedContainer.java
+++ b/src/main/java/lazy/baubles/container/PlayerExpandedContainer.java
@@ -72,7 +72,7 @@ public class PlayerExpandedContainer extends AbstractContainerMenu {
     @Override
     public void slotsChanged(@Nonnull Container container) {
         try {
-            Method onCraftChange = ObfuscationReflectionHelper.findMethod(CraftingMenu.class, "slotChangedCraftingGrid", AbstractContainerMenu.class, Level.class, Player.class, CraftingContainer.class, ResultContainer.class);
+            Method onCraftChange = ObfuscationReflectionHelper.findMethod(CraftingMenu.class, "m_150546_", AbstractContainerMenu.class, Level.class, Player.class, CraftingContainer.class, ResultContainer.class);
             onCraftChange.invoke(null, this, this.player.level, this.player, this.craftMatrix, this.craftResult);
         } catch (IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Current problem
`ObfuscationReflectionHelper#findMethod` requires an obfuscated method name. Currently, it uses the mojmaps name leading to a crash ingame. This likely came about when automatically updating method names from a previous Minecraft version.

## Fix in this PR
This PR changes the method name, `slotChangedCraftingGrid`, to its obfuscated equivalent `m_150546_`. Thus, it can now find the method and doesn't crash.

## Crash logs
- latest.log https://github.com/SuperMartijn642/PackedUp/files/7759798/latest.log
- Crash report https://github.com/SuperMartijn642/PackedUp/files/7759767/crash-2021-12-21_22.09.31-client.txt

These came from a report for Packed Up https://github.com/SuperMartijn642/PackedUp/issues/33.